### PR TITLE
Fix up linter in steve.election

### DIFF
--- a/v3/steve/election.py
+++ b/v3/steve/election.py
@@ -451,8 +451,8 @@ class Election:
         return [ row for row in db.q_owned.fetchall() ]
 
 
-def not_found(cursor, eid):
-    row = cursor.first_row(eid)
+def not_found(cursor, key):
+    row = cursor.first_row(key)
     return row is None
 
 

--- a/v3/steve/election.py
+++ b/v3/steve/election.py
@@ -184,7 +184,7 @@ class Election:
         if required_state:
             state = self._compute_state(md)
             if state != required_state:
-                raise ElectionBadState(state, required_state)
+                raise ElectionBadState(self.eid, state, required_state)
 
         return md
 
@@ -451,8 +451,8 @@ class Election:
         return [ row for row in db.q_owned.fetchall() ]
 
 
-def not_found(cursor, id):
-    row = cursor.first_row(id)
+def not_found(cursor, eid):
+    row = cursor.first_row(eid)
     return row is None
 
 
@@ -466,7 +466,8 @@ class ElectionNotFound(Exception):
 
 
 class ElectionBadState(Exception):
-    def __init__(self, current, required):
+    def __init__(self, eid, current, required):
+        self.eid = eid
         self.current = current
         self.required = required
         super().__init__(str(self))


### PR DESCRIPTION
See https://github.com/apache/steve/actions/runs/18642036170/job/53142684884

Fixes the following reports:

```
************* Module steve.election
steve/election.py:454:22: W0622: Redefining built-in 'id' (redefined-builtin)
steve/election.py:475:30: E1101: Instance of 'ElectionBadState' has no 'eid' member (no-member)
```

For reports on the module `server.pages`, I don't find related context that can drive a fix.

```
************* Module server.pages
server/pages.py:234:21: E0602: Undefined variable 'pid' (undefined-variable)
server/pages.py:289:10: E0602: Undefined variable 'flash_success' (undefined-variable)
server/pages.py:309:10: E0602: Undefined variable 'flash_success' (undefined-variable)
server/pages.py:337:10: E0602: Undefined variable 'flash_success' (undefined-variable)
server/pages.py:363:10: E0602: Undefined variable 'flash_success' (undefined-variable)
server/pages.py:383:10: E0602: Undefined variable 'flash_success' (undefined-variable)
```

cc @gstein 