### PR TITLE
Ask for owner_id when load_fakedata

### DIFF
--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -34,8 +34,8 @@ asfquart = ">=0.1.12"
 #faker = "^37.8.0"
 
 [tool.poetry.extras]
-server = ["asfquart"]         # Core dependencies for apache-steve[server]
-test = ["coverage", "pylint"] # Core dependencies for apache-steve[test]
+server = ["asfquart"]  # Core dependencies for apache-steve[server]
+test = ["coverage", "pylint"]  # Core dependencies for apache-steve[test]
 
 [build-system]
 requires = ["poetry-core"]

--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Apache STeVe Community <dev@steve.apache.org>"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/apache/steve"
-packages = [{include = "steve"}]
+packages = [{ include = "steve" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -34,8 +34,8 @@ asfquart = ">=0.1.12"
 #faker = "^37.8.0"
 
 [tool.poetry.extras]
-server = ["asfquart", ]  # Core dependencies for apache-steve[server]
-test = ["coverage", "pylint"]  # Core dependencies for apache-steve[test]
+server = ["asfquart"]         # Core dependencies for apache-steve[server]
+test = ["coverage", "pylint"] # Core dependencies for apache-steve[test]
 
 [build-system]
 requires = ["poetry-core"]

--- a/v3/server/bin/load_fakedata.py
+++ b/v3/server/bin/load_fakedata.py
@@ -17,8 +17,9 @@
 
 # Load a bunch of fake data into the database, for stuff to work with.
 
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
+import argparse
+import sqlite3
 import sys
 import pathlib
 import logging
@@ -40,15 +41,16 @@ import steve.crypto
 FAKE = faker.Faker()
 
 
-def main(owner, count=10):
+def main(owner_pid, count=10):
     for _ in range(count):
-        gen_election(owner)
+        gen_election(owner_pid)
 
 
-def gen_election(owner, issue_count=10):
+def gen_election(owner_pid, issue_count=10):
     title = FAKE.sentence()
-    e = steve.election.Election.create(DB_FNAME, title, owner)
-    _LOGGER.info(f'Created election[E:{e.eid}]: "{title}", by owner "{owner}"')
+    e = steve.election.Election.create(DB_FNAME, title, owner_pid)
+    _LOGGER.info(f'Created election[E:{e.eid}]: "{title}",'
+                 f' by owner "{owner_pid}"')
 
     for _ in range(issue_count):
         title = FAKE.sentence()
@@ -62,12 +64,28 @@ def gen_election(owner, issue_count=10):
         _LOGGER.info(f'[E:{e.eid}]: created issue[I:{iid}]: "{title}"')
 
 
+def random_owner():
+    "Pick a random PID from those available."
+
+    conn = sqlite3.connect(DB_FNAME)
+    cursor = conn.execute('SELECT pid FROM person ORDER BY RANDOM() LIMIT 1')
+    pid = cursor.fetchone()[0]
+    conn.close()
+
+    return pid
+
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
 
-    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--owner', type=str, required=True,
-                        help="The owner's Apache ID to use for created elections.")
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--owner-pid', type=str, required=False,
+                        help="The owner's Apache ID to use for created elections."
+                        " If not set, pick a random existing person.")
     args = parser.parse_args()
 
-    main(owner=args.owner)
+    owner_pid = args.owner_pid
+    if not owner_pid:
+        owner_pid = random_owner()
+
+    main(owner_pid=owner_pid)

--- a/v3/server/bin/load_fakedata.py
+++ b/v3/server/bin/load_fakedata.py
@@ -17,8 +17,9 @@
 
 # Load a bunch of fake data into the database, for stuff to work with.
 
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+
 import sys
-import sqlite3
 import pathlib
 import logging
 
@@ -39,19 +40,15 @@ import steve.crypto
 FAKE = faker.Faker()
 
 
-def main(count=10, owner_pid=None):
+def main(owner, count=10):
     for _ in range(count):
-        gen_election(owner_pid)
+        gen_election(owner)
 
 
-def gen_election(owner_pid=None, issue_count=10):
+def gen_election(owner, issue_count=10):
     title = FAKE.sentence()
-    if not owner_pid:
-        owner_pid = random_owner()
-        #owner_pid = 'gstein'
-    e = steve.election.Election.create(DB_FNAME, title, owner_pid)
-    _LOGGER.info(f'Created election[E:{e.eid}]: "{title}",'
-                 f' by owner "{owner_pid}"')
+    e = steve.election.Election.create(DB_FNAME, title, owner)
+    _LOGGER.info(f'Created election[E:{e.eid}]: "{title}", by owner "{owner}"')
 
     for _ in range(issue_count):
         title = FAKE.sentence()
@@ -65,17 +62,12 @@ def gen_election(owner_pid=None, issue_count=10):
         _LOGGER.info(f'[E:{e.eid}]: created issue[I:{iid}]: "{title}"')
 
 
-def random_owner():
-    "Pick a random PID from those available."
-
-    conn = sqlite3.connect(DB_FNAME)
-    cursor = conn.execute('SELECT pid FROM person ORDER BY RANDOM() LIMIT 1')
-    pid = cursor.fetchone()[0]
-    conn.close()
-
-    return pid
-
-
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    main()
+
+    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--owner', type=str, required=True,
+                        help="The owner's Apache ID to use for created elections.")
+    args = parser.parse_args()
+
+    main(owner=args.owner)

--- a/v3/server/certs/README.md
+++ b/v3/server/certs/README.md
@@ -6,7 +6,6 @@ In the `config.yaml` file under the `server` category are two values
 that point to your server's certificate:
 
 ```yaml
-
 server:
     certfile: server.crt
     keyfile: server.key
@@ -60,4 +59,5 @@ The certificate is at "./localhost.apache.org+3.pem" and the key at "./localhost
 It will expire on 29 December 2027 🗓
 ```
 
-Adjust the `config.yaml` to refer to these new files.
+Adjust the `config.yaml` to refer to these new files. The default `config.yaml.example`
+config assumes the generated files are moved under the `server/certs` directory.


### PR DESCRIPTION
Improve a bit of usability.

Also, I noticed that even the owner pid has a typo (like `tiso`), the insertions would be proceeded. Perhaps we can add a programmatic check or foreign key constraints to the DB.

cc @gstein 