### PR TITLE
Migrate from poetry to uv

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,13 +2,13 @@ name: Linting
 
 on:
   push:
+    branches: [ trunk ]
     paths:
       - 'v3/**/*.py'
       - '**/ruff.toml'
       - 'v3/pyproject.toml'
-
   pull_request:
-
+    branches: [ trunk ]
   workflow_dispatch:
 
 permissions:
@@ -17,34 +17,19 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        python-version: [3.12]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache Poetry dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pypoetry
-        key: ${{ runner.os }}-poetry-${{ hashFiles('v3/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-poetry-
-    - name: Install Poetry
-      run: |
-        python -m pip install poetry
+        python-version-file: v3/pyproject.toml
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
     - name: Install dependencies
       working-directory: v3  # Set the working directory to v3 where pyproject.toml is located
-      run: |
-        poetry install --with test,server
+      run: uv sync --all-extras --dev
     - name: Testing with ruff
       working-directory: v3  # Ensure ruff runs in the correct directory
-      run: |
-        poetry run ruff check
+      run: uv run ruff check

--- a/.github/workflows/type-tests.yml
+++ b/.github/workflows/type-tests.yml
@@ -2,13 +2,13 @@ name: Type Tests
 
 on:
   push:
+    branches: [ trunk ]
     paths:
       - 'v3/**/*.py'
       - '**/type-tests.yml'
       - 'v3/pyproject.toml'
-
   pull_request:
-
+    branches: [ trunk ]
   workflow_dispatch:
 
 permissions:
@@ -17,34 +17,19 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        python-version: [3.12]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Set up Python
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache Poetry dependencies
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pypoetry
-        key: ${{ runner.os }}-poetry-${{ hashFiles('v3/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-poetry-
-    - name: Install Poetry
-      run: |
-        python -m pip install poetry
+        python-version-file: v3/pyproject.toml
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
     - name: Install dependencies
       working-directory: v3  # Set the working directory to v3 where pyproject.toml is located
-      run: |
-        poetry install --with test,server
+      run: uv sync --all-extras --dev
     - name: Type testing with mypy
       working-directory: v3  # Ensure mypy runs in the correct directory
-      run: |
-        poetry run mypy --cache-dir /tmp/ --ignore-missing-imports .
+      run: uv run mypy --cache-dir /tmp/ --ignore-missing-imports .

--- a/v3/.gitignore
+++ b/v3/.gitignore
@@ -1,5 +1,6 @@
 steve.db
 poetry.lock
+uv.lock
 
 server/bin/bs.zip
 server/bin/icons.zip

--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -33,5 +33,15 @@ lint = [
     "types-aiofiles>=24.1.0,<25",
 ]
 
+
+[build-system]
+requires = ["uv_build"]
+build-backend = "uv_build"
+
 [tool.uv]
 default-groups = "all"
+
+# see https://docs.astral.sh/uv/reference/settings/#build-backend_module-name
+[tool.uv.build-backend]
+module-root = ""
+module-name = "steve"

--- a/v3/pyproject.toml
+++ b/v3/pyproject.toml
@@ -1,42 +1,37 @@
-[tool.poetry]
+[project]
 name = "apache-steve"
 version = "3.0.0"
+
+authors = [{ name = "Apache STeVe Community", email = "dev@steve.apache.org" }]
 description = "The Apache STeVe voting system."
-authors = ["Apache STeVe Community <dev@steve.apache.org>"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/apache/steve"
-packages = [{ include = "steve" }]
 
-[tool.poetry.dependencies]
-python = "^3.10"
-asfpy = ">=0.56"
-ezt = "^1.1"
-easydict = "^1.13"
-passlib = "^1.7.4"
-cryptography = "^44.0.3"
-argon2-cffi = "^25.1.0"
+dependencies = [
+    "asfpy>=0.56",
+    "asfquart>=0.1.12",
+    "ezt>=1.1",
+    "easydict>=1.13",
+    "passlib>=1.7.4,<2",
+    "cryptography>=44.0.3,<45",
+    "argon2-cffi>=25.1.0,<26",
+]
+requires-python = ">=3.10"
 
-[tool.poetry.group.test.dependencies]
-coverage = "^7.10.6"
-mypy = "^1.18.2"
-ruff = "^0.14.3"
-types-PyYAML = "^6.0.12"
-types-requests = "^2.32.4"
-types-aiofiles = "^24.1.0"
+[project.urls]
+Homepage = "https://steve.apache.org/"
+Repository = "https://github.com/apache/steve"
+Issues = "https://github.com/apache/steve/issues"
 
-[tool.poetry.group.server.dependencies]
-asfquart = ">=0.1.12"
-### not sure about this. not needed for server operation.
-### let the import fail, and the user can do a pip install.
-#python-ldap = "^3.0.0"
-### same. let this fail, if the user needs it.
-#faker = "^37.8.0"
+[dependency-groups]
+lint = [
+    "coverage>=7.10.6,<8",
+    "ruff>=0.14.3",
+    "mypy>=1.18.2,<2",
+    "types-PyYAML>=6.0.12,<7",
+    "types-requests>=2.32.4,<3",
+    "types-aiofiles>=24.1.0,<25",
+]
 
-[tool.poetry.extras]
-server = ["asfquart"]  # Core dependencies for apache-steve[server]
-test = ["coverage", "pylint"]  # Core dependencies for apache-steve[test]
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.uv]
+default-groups = "all"

--- a/v3/server/pages.py
+++ b/v3/server/pages.py
@@ -22,7 +22,6 @@
 ### authorization for various install scenarios and authn systems.
 ###
 
-import sys
 import pathlib
 import datetime
 import functools
@@ -35,6 +34,10 @@ import asfquart.session
 from asfquart.auth import Requirements as R
 import ezt
 
+import steve.election
+import steve.crypto
+import steve.persondb
+
 APP = asfquart.APP
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,11 +45,6 @@ THIS_DIR = pathlib.Path(__file__).resolve().parent
 DB_FNAME = THIS_DIR / APP.cfg.db
 TEMPLATES = THIS_DIR / 'templates'
 STATICDIR = THIS_DIR / 'static'
-
-sys.path.insert(0, str(THIS_DIR.parent))
-import steve.election  # noqa: E402
-import steve.crypto  # noqa: E402
-import steve.persondb  # noqa: E402
 
 # Formatted values to inject into templates.
 FMT_DATE = '%b %d'

--- a/v3/tests/run_stv.py
+++ b/v3/tests/run_stv.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,20 +16,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# ----
-#
-# ### TBD: DOCCO
-# USAGE: run_stv.py .../Meetings/yyyymmdd
-#
+
+
+# USAGE: uv run run_stv.py .../Meetings/yyyymmdd
 
 import sys
 import os.path
 
-# Ensure that we can import the "steve" package.
-THIS_DIR = os.path.realpath(os.path.dirname(__file__))
-sys.path.insert(0, os.path.dirname(THIS_DIR))
-import steve.vtypes.stv  # noqa: E402
+import steve.vtypes.stv
 
 # The stv module loads the stv_tool module. Tweak it.
 stv_tool = steve.vtypes.stv.stv_tool


### PR DESCRIPTION
This follows up #59 

The next steps in list:

1. Use `uv run` for `v3/server/bin` scripts. This needs to correspondingly update dependencies and `asf-load-ldap.py` & `load_fakedata.py` content.
2. Run code format `uv run ruff format` and assert the format in CI workflow.
3. Write a quickstart document based on the new setup.