### PR TITLE
Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Coding Agent Context
+
+This project uses `uv` for dependency management and enforces strict linting, formatting, and type-checking standards. All Coding Agents MUST follow these instructions after generating or modifying code to ensure compatibility with the project's CI/CD pipelines.
+
+## Post-Generation Checklist
+
+After making any changes, run the following commands in the `v3/` directory:
+
+1.  **Code Formatting**: Format the code using `ruff`.
+    ```bash
+    uv run ruff format .
+    ```
+
+2.  **Linting**: Run `ruff` check to identify and fix potential issues.
+    ```bash
+    uv run ruff check --fix .
+    ```
+
+3.  **Type Checking**: Verify type safety with `mypy`.
+    ```bash
+    uv run mypy --ignore-missing-imports .
+    ```
+
+## Development Standards
+
+- **Language**: All code, documentation, and comments MUST be written in **English**.
+- **Dependencies**: Use `uv` for all dependency management tasks (e.g., `uv sync`, `uv run`).
+- **CI Alignment**: These steps align with the `.github/workflows/linting.yml` and `.github/workflows/type-tests.yml` configurations.
+
+Ensure all checks pass before considering a task complete.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This project uses `uv` for dependency management and enforces strict linting, fo
 
 ## Post-Generation Checklist
 
-After making any changes, run the following commands in the `v3/` directory:
+From the repository root (where this `AGENTS.md` file lives), run the following commands inside the `v3/` directory:
 
 1.  **Code Formatting**: Format the code using `ruff`.
     ```bash


### PR DESCRIPTION
This adds a basic AGENTS.md file.

Then we may keep the agent working on the root directory. And I suppose once v3 is verified well, we can lift it to the root directory and clean up historical impls (they will be remained in the VCS, for sure).